### PR TITLE
Changed rustc_serialize crate link to suit changes to naming

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 
 extern crate event;
 extern crate input;
-extern crate "rustc-serialize" as rustc_serialize;
+extern crate rustc_serialize;
 
 pub use behavior::Behavior;
 pub use behavior::Behavior::{


### PR DESCRIPTION
What's the general rule with regard to minor rust-up related fixes like this? Should I just directly edit it in the main fork, or should I create a pull request for each one?